### PR TITLE
Script is picking wrong pipeline run

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -5,7 +5,7 @@ from arts.process_time_logo import process_time_logo
 from msrest.authentication import BasicAuthentication
 import getopt
 import sys
-import pprint
+import json
 
 
 def display_help():
@@ -46,7 +46,7 @@ def calculate_process_tine(args: ArgumentParseResult) -> None:
     pipelines_client = PipelinesClient(f'https://dev.azure.com/{args.azure_devops_organization}', credentials)
     runs = pipelines_client.list_runs(args.project, args.pipeline_id)
     previous_attempt = get_last_attempt_to_deliver(runs)
-    pprint.pp(previous_attempt)
+    print(json.dumps(previous_attempt.as_dict(), sort_keys=True, indent=4))
     print('Process time calculated!')
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -5,6 +5,7 @@ from arts.process_time_logo import process_time_logo
 from msrest.authentication import BasicAuthentication
 import getopt
 import sys
+import pprint
 
 
 def display_help():
@@ -45,7 +46,7 @@ def calculate_process_tine(args: ArgumentParseResult) -> None:
     pipelines_client = PipelinesClient(f'https://dev.azure.com/{args.azure_devops_organization}', credentials)
     runs = pipelines_client.list_runs(args.project, args.pipeline_id)
     previous_attempt = get_last_attempt_to_deliver(runs)
-    print(previous_attempt)
+    pprint.pp(previous_attempt)
     print('Process time calculated!')
 
 

--- a/src/parsers/get_last_attempt_to_deliver.py
+++ b/src/parsers/get_last_attempt_to_deliver.py
@@ -12,9 +12,9 @@ def get_last_attempt_to_deliver(runs: [Run]) -> Run:
     if failed_runs == 0:
         return runs[0]
     else:
-        if len(runs) == failed_runs + 1:
+        if len(runs) == failed_runs:
             return runs[0]
-        return runs[failed_runs + 1]
+        return runs[failed_runs]
 
 
 def amount_of_failed_previous_runs(runs: [Run]) -> int:

--- a/src/parsers/get_last_attempt_to_deliver.py
+++ b/src/parsers/get_last_attempt_to_deliver.py
@@ -1,10 +1,11 @@
+import json
+
 from azure.devops.v7_1.pipelines.models import Run
-import pprint
 
 
 def get_last_attempt_to_deliver(runs: [Run]) -> Run:
     """Get the last attempt to deliver from the list of pipelines."""
-    pprint.pp(runs)
+    print(json.dumps([run.as_dict() for run in runs], sort_keys=True, indent=4))
     if len(runs) == 1:
         return runs[0]
     failed_runs = amount_of_failed_previous_runs(runs)

--- a/src/parsers/get_last_attempt_to_deliver.py
+++ b/src/parsers/get_last_attempt_to_deliver.py
@@ -1,8 +1,10 @@
 from azure.devops.v7_1.pipelines.models import Run
+import pprint
 
 
 def get_last_attempt_to_deliver(runs: [Run]) -> Run:
     """Get the last attempt to deliver from the list of pipelines."""
+    pprint.pp(runs)
     if len(runs) == 1:
         return runs[0]
     failed_runs = amount_of_failed_previous_runs(runs)

--- a/tests/test_get_last_attempt_to_deliver.py
+++ b/tests/test_get_last_attempt_to_deliver.py
@@ -2,11 +2,13 @@ from azure.devops.v7_1.pipelines.models import Run
 from src.parsers.get_last_attempt_to_deliver import get_last_attempt_to_deliver
 from tests.generate_test_run import generate_test_run
 
+
 def test_only_current_run_exist_should_return_current_run():
     current_run = generate_test_run(3, 'succeeded')
     pipelines = [current_run]
     result = get_last_attempt_to_deliver(pipelines)
     assert result.id == current_run.id
+
 
 def test_previous_run_was_successful_return_current_run():
     current_run = generate_test_run(3, 'succeeded')
@@ -15,26 +17,29 @@ def test_previous_run_was_successful_return_current_run():
     result = get_last_attempt_to_deliver(pipelines)
     assert result.id == current_run.id
 
-def test_previous_run_was_failed_but_no_more_runs_return_current_run():
+
+def test_previous_run_was_failed_but_no_more_runs_return_previous_run():
     current_run = generate_test_run(3, 'succeeded')
     previous_run = generate_test_run(2, 'failed')
     pipelines = [current_run, previous_run]
     result = get_last_attempt_to_deliver(pipelines)
-    assert result.id == current_run.id
+    assert result.id == previous_run.id
 
-def test_previous_run_was_failed_return_last_successful():
+
+def test_previous_run_was_failed_return_failed_before_successful():
     current_run = generate_test_run(3, 'succeeded')
     previous_run = generate_test_run(2, 'failed')
     previous_run2 = generate_test_run(1, 'succeeded')
     pipelines = [current_run, previous_run, previous_run2]
     result = get_last_attempt_to_deliver(pipelines)
-    assert result.id == previous_run2.id
+    assert result.id == previous_run.id
 
-def test_two_previous_runs_both_failed_return_last_successful():
+
+def test_two_previous_runs_both_failed_return_last_failed_before_successful():
     current_run = generate_test_run(3, 'succeeded')
     previous_run = generate_test_run(2, 'failed')
     previous_run2 = generate_test_run(1, 'failed')
     previous_run3 = generate_test_run(0, 'succeeded')
     pipelines = [current_run, previous_run, previous_run2, previous_run3]
     result = get_last_attempt_to_deliver(pipelines)
-    assert result.id == previous_run3.id
+    assert result.id == previous_run2.id


### PR DESCRIPTION
It ran against this pipeline definition - https://dev.azure.com/worldpwn/process-time/_build?definitionId=2
Run - https://dev.azure.com/worldpwn/process-time/_build/results?buildId=17&view=results

It should pick the last successful, but it picked the first successful.
<img width="1175" alt="image" src="https://github.com/worldpwn/process-time-azure-devops/assets/6351780/2c2d7d42-0322-44a7-aee4-a0c9a2e8ef6b">
